### PR TITLE
Modify `dpo_loss` function to use response choice probability p from …

### DIFF
--- a/cdpo/cdpo_trainer.py
+++ b/cdpo/cdpo_trainer.py
@@ -1082,7 +1082,7 @@ class GeneralizedDPOTrainer(Trainer):
         q_clamped = torch.clamp(q, eps, 1 - eps)
 
         # Create grid of candidate p values
-        p_grid = torch.linspace(0.5, 1 - eps, grid_size, device=q.device, dtype=q.dtype)
+        p_grid = torch.linspace(eps, 1 - eps, grid_size, device=q.device, dtype=q.dtype)
         
         # Expand dimensions for broadcasting: [batch_size, 1] and [1, grid_size]
         q_expanded = q_clamped.unsqueeze(-1)  # [batch_size, 1]


### PR DESCRIPTION
### Changes

1. Change to nu=0.1 (most important change)
2. Replace binary search with a simple grid search over 100 points. There is no speed loss (it’s slightly faster, actually). The function is simpler and includes other minor numerical stability improvements.
3. Call the self.optimize_p_on_kl_boundary()  method with logits detached since gradient tracking is not needed
 
Fixes #3